### PR TITLE
feat: :sparkles: Add customClass prop for highlight styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9073,7 +9073,7 @@
     },
     "packages/vue-pdf": {
       "name": "@tato30/vue-pdf",
-      "version": "1.11.2",
+      "version": "1.11.3",
       "license": "MIT",
       "dependencies": {
         "pdfjs-dist": "4.9.124"

--- a/packages/playground/App.vue
+++ b/packages/playground/App.vue
@@ -1,14 +1,44 @@
 <!-- eslint-disable unused-imports/no-unused-imports -->
 <!-- Use this component to play with the main components -->
 <script setup lang="ts">
-import pdf14 from '@samples/issue126.pdf';
-import { VuePDF, usePDF } from '@tato30/vue-pdf';
+import pdf14 from "@samples/45.pdf";
+import { VuePDF, usePDF } from "@tato30/vue-pdf";
+import { ref } from "vue";
 
-const { pdf } = usePDF(pdf14)
+const { pdf } = usePDF(
+  "https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf"
+);
+
+const highlightText = ref("javascript");
+const highlightOptions = ref({
+  completeWords: false,
+  ignoreCase: true,
+});
 </script>
 
 <template>
   <div>
-    <VuePDF :pdf="pdf" annotation-layer />
+    <VuePDF
+      :pdf="pdf"
+      text-layer
+      :highlight-text="highlightText"
+      :highlightOptions="highlightOptions"
+      custom-highlight-class="custom"
+    />
   </div>
 </template>
+
+<style>
+.custom {
+  background: linear-gradient(
+    0deg,
+    rgba(53, 184, 255, 0.2),
+    rgba(53, 184, 255, 0.2)
+  );
+  background-color: transparent;
+  border: 2px solid;
+  border-image-source: linear-gradient(147.05deg, #a095ff 0%, #e294ff 100%);
+  border-image-slice: 1;
+  cursor: pointer;
+}
+</style>

--- a/packages/vue-pdf/src/components/VuePDF.vue
+++ b/packages/vue-pdf/src/components/VuePDF.vue
@@ -57,6 +57,7 @@ const props = withDefaults(
     highlightText?: string | string[];
     highlightOptions?: HighlightOptions;
     highlightPages?: number[];
+    customHighlightClass?: string;
   }>(),
   {
     page: 1,
@@ -102,6 +103,7 @@ const tlayerProps = computed(() => {
     highlightText: props.highlightText,
     highlightOptions: props.highlightOptions,
     highlightPages: props.highlightPages,
+    customHighlightClass: props.customHighlightClass,
   };
 });
 

--- a/packages/vue-pdf/src/components/layers/TextLayer.vue
+++ b/packages/vue-pdf/src/components/layers/TextLayer.vue
@@ -16,6 +16,7 @@ const props = defineProps<{
   highlightText?: string | string[];
   highlightOptions?: HighlightOptions;
   hightlightPages?: number[];
+  customHighlightClass?: string;
 }>();
 
 const emit = defineEmits<{
@@ -59,7 +60,12 @@ async function findAndHighlight(reset = false) {
       textContent!,
       getHighlightOptionsWithDefaults()
     );
-    highlightMatches(matches, textContent!, textDivs);
+    highlightMatches(
+      matches,
+      textContent!,
+      textDivs,
+      props.customHighlightClass || "highlight"
+    );
     emit("highlight", {
       matches,
       textContent,

--- a/packages/vue-pdf/src/components/utils/highlight.ts
+++ b/packages/vue-pdf/src/components/utils/highlight.ts
@@ -1,213 +1,228 @@
-import type { TextItem } from 'pdfjs-dist/types/src/display/api'
-import type { TextContent } from 'pdfjs-dist/types/src/display/text_layer'
-import type { HighlightOptions, Match } from '../types'
+import type { TextItem } from "pdfjs-dist/types/src/display/api";
+import type { TextContent } from "pdfjs-dist/types/src/display/text_layer";
+import type { HighlightOptions, Match } from "../types";
 
-function searchQuery(textContent: TextContent, query: string, options: HighlightOptions) {
-  const strs = []
+function searchQuery(
+  textContent: TextContent,
+  query: string,
+  options: HighlightOptions
+) {
+  const strs = [];
   for (const textItem of textContent.items as TextItem[]) {
     if (textItem.hasEOL) {
       // Remove the break line hyphen in the middle of the sentence
-      if (textItem.str.endsWith('-')) {
-        const lastHyphen = textItem.str.lastIndexOf('-')
-        strs.push(textItem.str.substring(0, lastHyphen))
+      if (textItem.str.endsWith("-")) {
+        const lastHyphen = textItem.str.lastIndexOf("-");
+        strs.push(textItem.str.substring(0, lastHyphen));
+      } else {
+        strs.push(textItem.str, "\n");
       }
-      else {
-        strs.push(textItem.str, '\n')
-      }
-    }
-    else {
-      strs.push(textItem.str)
+    } else {
+      strs.push(textItem.str);
     }
   }
 
   // Join the text as is presented in textlayer and then replace newlines (/n) with whitespaces
-  const textJoined = strs.join('').replace(/\n/g, ' ')
+  const textJoined = strs.join("").replace(/\n/g, " ");
 
-  const regexFlags = ['g']
-  if (options.ignoreCase)
-    regexFlags.push('i')
+  const regexFlags = ["g"];
+  if (options.ignoreCase) regexFlags.push("i");
 
   // Trim the query and escape all regex special characters
   let fquery = query.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (options.completeWords)
-    fquery = `\\b${fquery}\\b`
+  if (options.completeWords) fquery = `\\b${fquery}\\b`;
 
-  const regex = new RegExp(fquery, regexFlags.join(''))
+  const regex = new RegExp(fquery, regexFlags.join(""));
 
-  const matches = []
-  let match
+  const matches = [];
+  let match;
 
   // eslint-disable-next-line no-cond-assign
   while ((match = regex.exec(textJoined)) !== null)
-    matches.push([match.index, match[0].length, match[0]])
+    matches.push([match.index, match[0].length, match[0]]);
 
-  return matches
+  return matches;
 }
 
-function convertMatches(matches: (number | string)[][], textContent: TextContent): Match[] {
+function convertMatches(
+  matches: (number | string)[][],
+  textContent: TextContent
+): Match[] {
   function endOfLineOffset(item: TextItem) {
     // When textitem has a EOL flag and the string has a hyphen at the end
     // the hyphen should be removed (-1 len) so the sentence could be searched as a joined one.
     // In other cases the EOL flag introduce a whitespace (+1 len) between two different sentences
     if (item.hasEOL) {
-      if (item.str.endsWith('-'))
-        return -1
-      else
-        return 1
+      if (item.str.endsWith("-")) return -1;
+      else return 1;
     }
-    return 0
+    return 0;
   }
 
-  let index = 0
-  let tindex = 0
-  const textItems = textContent.items as TextItem[]
-  const end = textItems.length - 1
+  let index = 0;
+  let tindex = 0;
+  const textItems = textContent.items as TextItem[];
+  const end = textItems.length - 1;
 
-  const convertedMatches = []
+  const convertedMatches = [];
 
   // iterate over all matches
   for (let m = 0; m < matches.length; m++) {
-    let mindex = matches[m][0] as number
+    let mindex = matches[m][0] as number;
 
     while (index !== end && mindex >= tindex + textItems[index].str.length) {
-      const item = textItems[index]
-      tindex += item.str.length + endOfLineOffset(item)
-      index++
+      const item = textItems[index];
+      tindex += item.str.length + endOfLineOffset(item);
+      index++;
     }
 
     const divStart = {
       idx: index,
       offset: mindex - tindex,
-    }
+    };
 
-    mindex += matches[m][1] as number
+    mindex += matches[m][1] as number;
 
     while (index !== end && mindex > tindex + textItems[index].str.length) {
-      const item = textItems[index]
-      tindex += item.str.length + endOfLineOffset(item)
-      index++
+      const item = textItems[index];
+      tindex += item.str.length + endOfLineOffset(item);
+      index++;
     }
 
     const divEnd = {
       idx: index,
       offset: mindex - tindex,
-    }
+    };
     convertedMatches.push({
       start: divStart,
       end: divEnd,
       str: matches[m][2] as string,
       oindex: matches[m][0] as number,
-    })
+    });
   }
-  return convertedMatches
+  return convertedMatches;
 }
 
-function highlightMatches(matches: Match[], textContent: TextContent, textDivs: HTMLElement[]) {
+function highlightMatches(
+  matches: Match[],
+  textContent: TextContent,
+  textDivs: HTMLElement[],
+  customHighlightClass: string = "highlight"
+) {
   function appendHighlightDiv(idx: number, startOffset = -1, endOffset = -1) {
-    const textItem = textContent.items[idx] as TextItem
-    const nodes = []
+    const textItem = textContent.items[idx] as TextItem;
+    const nodes = [];
 
-    let content = ''
-    let prevContent = ''
-    let nextContent = ''
+    let content = "";
+    let prevContent = "";
+    let nextContent = "";
 
-    let div = textDivs[idx]
+    let div = textDivs[idx];
 
-    if (!div)
-      return // don't process if div is undefinied
+    if (!div) return; // don't process if div is undefinied
 
     if (div.nodeType === Node.TEXT_NODE) {
-      const span = document.createElement('span')
-      div.before(span)
-      span.append(div)
-      textDivs[idx] = span
-      div = span
+      const span = document.createElement("span");
+      div.before(span);
+      span.append(div);
+      textDivs[idx] = span;
+      div = span;
     }
 
     if (startOffset >= 0 && endOffset >= 0)
-      content = textItem.str.substring(startOffset, endOffset)
-    else if (startOffset < 0 && endOffset < 0)
-      content = textItem.str
-    else if (startOffset >= 0)
-      content = textItem.str.substring(startOffset)
-    else if (endOffset >= 0)
-      content = textItem.str.substring(0, endOffset)
+      content = textItem.str.substring(startOffset, endOffset);
+    else if (startOffset < 0 && endOffset < 0) content = textItem.str;
+    else if (startOffset >= 0) content = textItem.str.substring(startOffset);
+    else if (endOffset >= 0) content = textItem.str.substring(0, endOffset);
 
-    const node = document.createTextNode(content)
-    const span = document.createElement('span')
-    span.className = 'highlight appended'
-    span.append(node)
+    const node = document.createTextNode(content);
+    const span = document.createElement("span");
+    span.className = `${customHighlightClass} appended`;
+    span.append(node);
 
-    nodes.push(span)
+    nodes.push(span);
 
     if (startOffset > 0) {
-      if (div.childNodes.length === 1 && div.childNodes[0].nodeType === Node.TEXT_NODE) {
-        prevContent = textItem.str.substring(0, startOffset)
-        const node = document.createTextNode(prevContent)
-        nodes.unshift(node)
-      }
-      else {
-        let alength = 0
-        const prevNodes = []
+      if (
+        div.childNodes.length === 1 &&
+        div.childNodes[0].nodeType === Node.TEXT_NODE
+      ) {
+        prevContent = textItem.str.substring(0, startOffset);
+        const node = document.createTextNode(prevContent);
+        nodes.unshift(node);
+      } else {
+        let alength = 0;
+        const prevNodes = [];
         for (const childNode of div.childNodes) {
-          const textValue = childNode.nodeType === Node.TEXT_NODE
-            ? childNode.nodeValue!
-            : childNode.firstChild!.nodeValue!
-          alength += textValue.length
+          const textValue =
+            childNode.nodeType === Node.TEXT_NODE
+              ? childNode.nodeValue!
+              : childNode.firstChild!.nodeValue!;
+          alength += textValue.length;
 
-          if (alength <= startOffset)
-            prevNodes.push(childNode)
-          else if (startOffset >= alength - textValue.length && endOffset <= alength)
-            prevNodes.push(document.createTextNode(textValue.substring(0, startOffset - (alength - textValue.length))))
+          if (alength <= startOffset) prevNodes.push(childNode);
+          else if (
+            startOffset >= alength - textValue.length &&
+            endOffset <= alength
+          )
+            prevNodes.push(
+              document.createTextNode(
+                textValue.substring(
+                  0,
+                  startOffset - (alength - textValue.length)
+                )
+              )
+            );
         }
-        nodes.unshift(...prevNodes)
+        nodes.unshift(...prevNodes);
       }
     }
     if (endOffset > 0) {
-      nextContent = textItem.str.substring(endOffset)
-      const node = document.createTextNode(nextContent)
-      nodes.push(node)
+      nextContent = textItem.str.substring(endOffset);
+      const node = document.createTextNode(nextContent);
+      nodes.push(node);
     }
 
-    div.replaceChildren(...nodes)
+    div.replaceChildren(...nodes);
   }
 
   for (const match of matches) {
     if (match.start.idx === match.end.idx) {
-      appendHighlightDiv(match.start.idx, match.start.offset, match.end.offset)
-    }
-    else {
+      appendHighlightDiv(match.start.idx, match.start.offset, match.end.offset);
+    } else {
       for (let si = match.start.idx, ei = match.end.idx; si <= ei; si++) {
-        if (si === match.start.idx)
-          appendHighlightDiv(si, match.start.offset)
+        if (si === match.start.idx) appendHighlightDiv(si, match.start.offset);
         else if (si === match.end.idx)
-          appendHighlightDiv(si, -1, match.end.offset)
-        else
-          appendHighlightDiv(si)
+          appendHighlightDiv(si, -1, match.end.offset);
+        else appendHighlightDiv(si);
       }
     }
   }
 }
 
 function resetDivs(textContent: TextContent, textDivs: HTMLElement[]) {
-  const textItems = textContent.items.map(val => (val as TextItem).str)
+  const textItems = textContent.items.map((val) => (val as TextItem).str);
   for (let idx = 0; idx < textDivs.length; idx++) {
-    const div = textDivs[idx]
+    const div = textDivs[idx];
 
     if (div && div.nodeType !== Node.TEXT_NODE) {
-      const textNode = document.createTextNode(textItems[idx])
-      div.replaceChildren(textNode)
+      const textNode = document.createTextNode(textItems[idx]);
+      div.replaceChildren(textNode);
     }
   }
 }
 
-function findMatches(queries: string[], textContent: TextContent, options: HighlightOptions) {
-  const convertedMatches = []
+function findMatches(
+  queries: string[],
+  textContent: TextContent,
+  options: HighlightOptions
+) {
+  const convertedMatches = [];
   for (const query of queries) {
-    const matches = searchQuery(textContent, query, options)
-    convertedMatches.push(...convertMatches(matches, textContent))
+    const matches = searchQuery(textContent, query, options);
+    convertedMatches.push(...convertMatches(matches, textContent));
   }
-  return convertedMatches
+  return convertedMatches;
 }
 
-export { findMatches, highlightMatches, resetDivs }
+export { findMatches, highlightMatches, resetDivs };


### PR DESCRIPTION
### Add customClass prop for highlight styling 
 
This PR introduces the following changes: 
- Add a new `customHighlightClass` prop to VuePDF component 
- Modify TextLayer component to accept and use the `customHighlightClass` prop 
- Update highlightMatches function to use the custom class 
- Adjust App.vue to demonstrate usage of the new `customHighlightClass` prop  

These changes allow users to easily customize the styling of highlighted text in the PDF viewer by passing a custom CSS class name. If no custom class is provided, the default 'highlight' class is used.